### PR TITLE
New test case for Google shortenerAPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - python setup.py install

--- a/tests/test_google_minify.py
+++ b/tests/test_google_minify.py
@@ -1,5 +1,5 @@
 import unittest
-from microurl.google import google_mini
+from microurl.google import google_mini, google_expand
 
 GOOGLE_API_KEY = 'AIzaSyB_nDH7Uvm6-KSbsJD_OqYXA2XmuZ1P1lE'
 
@@ -22,6 +22,19 @@ class Testwrongurl(unittest.TestCase):
     def test_wrong_url(self):
         with self.assertRaises(KeyError):
             google_mini('wrong urlpattern', GOOGLE_API_KEY)
+
+
+class TestMinifyAndExpand(unittest.TestCase):
+
+    def test_minify_and_expand(self):
+        test_url = 'https://micropyramid.com/'
+
+        minified_url = google_mini(test_url, GOOGLE_API_KEY)
+        self.assertTrue(minified_url)
+
+        expanded_url = google_expand(minified_url, GOOGLE_API_KEY)
+        self.assertEqual(test_url, expanded_url)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a new test (cf. #2) for the Google shortener API; coverage is now 81% for this file.
Also added python 3.6 in the travis.yml configuration file.
Note: python 3.3 is [not supposed to be supported anymore](https://www.python.org/dev/peps/pep-0398/#x-end-of-life), maybe it should be removed from this file as well?